### PR TITLE
Type safe examples (Request Body & Responses)

### DIFF
--- a/src/core/body.ts
+++ b/src/core/body.ts
@@ -5,12 +5,16 @@ import { safeParse } from "./zod-error-handler";
 import type { RequestBodyObject } from "@omer-x/openapi-types/request-body";
 import type { ZodError, ZodType, ZodTypeDef } from "zod";
 
-export function resolveRequestBody<I, O>(source?: ZodType<O, ZodTypeDef, I> | string, isFormData: boolean = false) {
+export function resolveRequestBody<I, O>(
+  source?: ZodType<O, ZodTypeDef, I> | string,
+  isFormData: boolean = false,
+  customExample?: O,
+) {
   if (!source) return undefined;
   return {
     // description: "", // how to fill this?
     required: true,
-    content: resolveContent(source, false, isFormData),
+    content: resolveContent(source, false, isFormData, customExample),
   } as RequestBodyObject;
 }
 

--- a/src/core/content.ts
+++ b/src/core/content.ts
@@ -1,16 +1,20 @@
 import { createSchemaRef } from "~/utils/openapi-components";
+import createMediaType from "./createMediaType";
 import convertToOpenAPI from "./zod-to-openapi";
 import type { RequestBodyObject } from "@omer-x/openapi-types/request-body";
 import type { ZodType } from "zod";
 
-export function resolveContent(source?: ZodType<unknown> | string, isArray: boolean = false, isFormData: boolean = false) {
+export function resolveContent(
+  source?: ZodType<unknown> | string,
+  isArray: boolean = false,
+  isFormData: boolean = false,
+  customExample?: unknown,
+) {
   if (!source) return undefined;
 
   const schema = typeof source === "string" ? createSchemaRef(source, isArray) : convertToOpenAPI(source, isArray);
 
   return {
-    [isFormData ? "multipart/form-data" : "application/json"]: {
-      schema,
-    },
+    [isFormData ? "multipart/form-data" : "application/json"]: createMediaType(schema, customExample),
   } as RequestBodyObject["content"];
 }

--- a/src/core/createMediaType.test.ts
+++ b/src/core/createMediaType.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "@jest/globals";
+import createMediaType from "./createMediaType";
+import type { SchemaObject } from "@omer-x/openapi-types/schema";
+
+describe("createMediaType", () => {
+  const mockSchema: SchemaObject = { type: "string" };
+  const mockExample = "example text";
+
+  it("should create a MediaTypeObject with only the schema", () => {
+    expect(createMediaType(mockSchema)).toStrictEqual({
+      schema: mockSchema,
+    });
+  });
+
+  it("should create a MediaTypeObject with schema and example when example is provided", () => {
+    expect(createMediaType(mockSchema, mockExample)).toStrictEqual({
+      schema: mockSchema,
+      example: mockExample,
+    });
+  });
+});

--- a/src/core/createMediaType.ts
+++ b/src/core/createMediaType.ts
@@ -1,0 +1,12 @@
+import type { Entry } from "~/types/entry";
+import type { MediaTypeObject } from "@omer-x/openapi-types/media-type";
+import type { SchemaObject } from "@omer-x/openapi-types/schema";
+
+export default function createMediaType(schema: SchemaObject, example?: MediaTypeObject["example"]) {
+  const mediaTypeEntries = [] as Entry<MediaTypeObject>[];
+  mediaTypeEntries.push(["schema", schema]);
+  if (example) {
+    mediaTypeEntries.push(["example", example]);
+  }
+  return Object.fromEntries(mediaTypeEntries) as MediaTypeObject;
+}

--- a/src/core/definer.ts
+++ b/src/core/definer.ts
@@ -1,7 +1,7 @@
 import { customErrorTypes } from "~/types/error";
 import type { HttpMethod } from "~/types/http";
 import type { RouteHandler, RouteMethodHandler } from "~/types/next";
-import type { ResponseDefinition } from "~/types/response";
+import type { ResponseCollection } from "~/types/response";
 import { parseRequestBody, resolveRequestBody } from "./body";
 import { resolveParams } from "./params";
 import parsePathParams from "./path-params";
@@ -40,6 +40,7 @@ type RouteOptions<
   RequestBodyOutput,
   Req extends Request,
   Res extends Response,
+  ResponseDefinitions extends Record<string, unknown>,
 > = {
   operationId: string,
   method: Method,
@@ -52,7 +53,7 @@ type RouteOptions<
     source: ActionSource<PathParamsOutput, QueryParamsOutput, RequestBodyOutput>,
     request: Req
   ) => Res | Promise<Res>,
-  responses: Record<string, ResponseDefinition>,
+  responses: ResponseCollection<ResponseDefinitions>,
   handleErrors?: (
     errorType: typeof customErrorTypes[number] | "UNKNOWN_ERROR",
     issues?: ZodIssue[]
@@ -64,9 +65,18 @@ type RouteOptions<
 } & (RouteWithBody<RequestBodyInput, RequestBodyOutput> | RouteWithoutBody);
 
 function defineRoute<
-  M extends HttpMethod, PPI, PPO, QPI, QPO, RBI, RBO, MwReq extends Request, MwRes extends Response,
+  M extends HttpMethod,
+  PPI,
+  PPO,
+  QPI,
+  QPO,
+  RBI,
+  RBO,
+  MwReq extends Request,
+  MwRes extends Response,
+  ResDef extends Record<string, unknown>,
 >(input: RouteOptions<
-  M, PPI, PPO, QPI, QPO, RBI, RBO, MwReq, MwRes
+  M, PPI, PPO, QPI, QPO, RBI, RBO, MwReq, MwRes, ResDef
 >) {
   const handler: RouteMethodHandler<PPI, MwReq, MwRes> = async (request, context) => {
     try {

--- a/src/core/definer.ts
+++ b/src/core/definer.ts
@@ -19,12 +19,14 @@ type ActionSource<PathParams, QueryParams, RequestBody> = {
 type RouteWithoutBody = {
   method: Extract<HttpMethod, "GET" | "DELETE" | "HEAD">,
   requestBody?: null,
+  requestBodyExample?: undefined,
   hasFormData?: boolean,
 };
 
 type RouteWithBody<I, O> = {
   method: Exclude<HttpMethod, "GET" | "DELETE" | "HEAD">,
   requestBody?: ZodType<O, ZodTypeDef, I> | string,
+  requestBodyExample?: NoInfer<O>,
   hasFormData?: boolean,
 };
 
@@ -125,7 +127,7 @@ function defineRoute<
     description: input.description,
     tags: input.tags,
     parameters: parameters.length ? parameters : undefined,
-    requestBody: resolveRequestBody(input.requestBody ?? undefined, input.hasFormData),
+    requestBody: resolveRequestBody(input.requestBody ?? undefined, input.hasFormData, input.requestBodyExample),
     responses: responses,
     security: input.security,
   };

--- a/src/core/responses.test.ts
+++ b/src/core/responses.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import type { ResponseDefinition } from "~/types/response";
+import type { ResponseCollection } from "~/types/response";
 import { addBadRequest, bundleResponses } from "./responses";
 
 describe("addBadRequest", () => {
@@ -26,13 +26,11 @@ describe("addBadRequest", () => {
 
 describe("bundleResponses", () => {
   it("should return an empty when no responses are provided", () => {
-    const collection: Record<string, ResponseDefinition> = {};
-    const result = bundleResponses(collection);
-    expect(result).toEqual({});
+    expect(bundleResponses({})).toEqual({});
   });
 
   it("should return bundled responses with correct descriptions and resolved content", () => {
-    const collection: Record<string, ResponseDefinition> = {
+    const collection: ResponseCollection<Record<number, unknown>> = {
       200: { description: "Success", content: "SomeContent", isArray: false },
       404: { description: "Not Found", content: "SomeOtherContent", isArray: true },
     };

--- a/src/core/responses.ts
+++ b/src/core/responses.ts
@@ -1,4 +1,4 @@
-import type { ResponseDefinition } from "~/types/response";
+import type { ResponseCollection, ResponseDefinition } from "~/types/response";
 import { resolveContent } from "./content";
 import type { ResponseObject, ResponsesObject } from "@omer-x/openapi-types/response";
 
@@ -7,13 +7,13 @@ export function addBadRequest(queryParams?: unknown, requestBody?: unknown) {
   return { description: "Bad Request" } as ResponseObject;
 }
 
-export function bundleResponses(collection: Record<string, ResponseDefinition>) {
-  return Object.entries(collection).reduce((result, [key, response]) => {
+export function bundleResponses<Defs extends Record<string, unknown>>(collection: ResponseCollection<Defs>) {
+  return Object.entries(collection).reduce((result, [key, response]: [string, ResponseDefinition<unknown>]) => {
     return {
       ...result,
       [key]: {
         description: response.description,
-        content: resolveContent(response.content, response.isArray),
+        content: resolveContent(response.content, response.isArray, false, response.example),
       } satisfies ResponseObject,
     };
   }, {}) as ResponsesObject;

--- a/src/types/entry.ts
+++ b/src/types/entry.ts
@@ -1,0 +1,1 @@
+export type Entry<T> = [keyof T, T[keyof T]];

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -1,7 +1,12 @@
-import type { ZodType } from "zod";
+import type { ZodType, ZodTypeDef } from "zod";
 
-export type ResponseDefinition = {
+export type ResponseDefinition<O, I = O> = {
   description: string,
-  content?: ZodType | string,
   isArray?: boolean,
+  content?: ZodType<O, ZodTypeDef, I> | string,
+  example?: NoInfer<O>,
+};
+
+export type ResponseCollection<T extends Record<string, unknown>> = {
+  [K in keyof T]: ResponseDefinition<T[K]>;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `customExample` parameter in the request body and content resolution functions, enhancing flexibility in handling request and response examples.
	- Added a new function, `createMediaType`, to construct media type objects with optional examples.
	- New type alias `Entry<T>` for structured key-value representation.

- **Bug Fixes**
	- Improved type safety and structure in response handling, ensuring better handling of response collections.

- **Documentation**
	- Updated method signatures and type definitions for clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->