### PR TITLE
Propagate `ZodError` as `cause` for `PARSE_PATH_PARAMS`

### DIFF
--- a/src/core/path-params.ts
+++ b/src/core/path-params.ts
@@ -11,6 +11,6 @@ export default function parsePathParams<I, O>(source?: I, schema?: ZodType<O, Zo
       // eslint-disable-next-line no-console
       console.log((error as ZodError).issues);
     }
-    throw new Error("PARSE_PATH_PARAMS");
+    throw new Error("PARSE_PATH_PARAMS", { cause: (error as ZodError).issues });
   }
 }


### PR DESCRIPTION
## Description

Hi there, thank you for making this library! It's very useful to generate OpenAPI schemas from Next.js's API route.

I noticed one thing that seems to be missing. Let's say for this code (in `app/api/[symbol]`):

```ts
import defineRoute from "@omer-x/next-openapi-route-handler";
import { z } from "zod";

export const { GET } = defineRoute({
	operationId: "getSymbol",
	method: "GET",
	summary: "Get a symbol",
	description: "Returns an object with the symbol as one of its properties.",
	tags: ["symbol"],
	pathParams: z.object({ symbol: z.enum(["QQQ", "SPY", "FXI"]) }),
	action: ({ pathParams }) => {
		return Response.json({ ticker: pathParams.symbol }, { status: 200 });
	},
	responses: {
		200: { description: "OK", content: z.object({ ticker: z.string() }) },
		422: { description: "Invalid parameters", content: z.array(z.string()) },
		500: { description: "Internal server error", content: "string" },
	},
	handleErrors: (errorType, issues) => {
		// Sample logging. Check this out in the output.
		console.log(errorType, issues);

		if (errorType === "PARSE_PATH_PARAMS") {
			// FIXME: `issues` does not have Zod issue, even though `PARSE_PATH_PARAMS` should have
			// Zod issues since it's validated by it.
			return Response.json(
				issues?.map((value) => value.path.toString()),
				{ status: 422 },
			);
		}

		return new Response("Internal server error", { status: 500 });
	},
});
```

This is the response, which I don't think is correct. `issues` should not be `undefined` since from the code above, `pathParams` are validated by the Zod schema.

```
[
  {
    received: 'BBRI.JK',
    code: 'invalid_enum_value',
    options: [ 'QQQ', 'SPY', 'FXI' ],
    path: [ 'symbol' ],
    message: "Invalid enum value. Expected 'QQQ' | 'SPY' | 'FXI', received 'BBRI.JK'"
  }
]
PARSE_PATH_PARAMS undefined // <- this should not be the case!
 ⨯ TypeError: Value is not JSON serializable
    at Object.handleErrors (app/api/[symbol]/route.ts:26:19)
  24 | 			// FIXME: `issues` does not have Zod issue, even though `PARSE_PATH_PARAMS` should have
  25 | 			// Zod issues since it's validated by it.
> 26 | 			return Response.json(
     | 			               ^
  27 | 				issues?.map((value) => value.path.toString()),
  28 | 				{ status: 422 },
  29 | 			);
 ⨯ TypeError: Value is not JSON serializable
    at Object.handleErrors (app/api/[symbol]/route.ts:26:19)
  24 | 			// FIXME: `issues` does not have Zod issue, even though `PARSE_PATH_PARAMS` should have
  25 | 			// Zod issues since it's validated by it.
> 26 | 			return Response.json(
     | 			               ^
  27 | 				issues?.map((value) => value.path.toString()),
  28 | 				{ status: 422 },
  29 | 			);
 GET /api/BBRI.JK 500 in 1568ms
```

## Expected Behavior

I think `issues` should not be `undefined`. I noticed that for `PARSE_PATH_PARAMS`, we didn't put the `ZodError` as part of the `cause`. So, this PR should fix it.

## Future

In the future, would be nice to strategically structure the code in such a way that if we get one of these error types, `issues` should never be `undefined` since these validations will always have to pass through the Zod schema, so `ZodError` shall always be there.

- `PARSE_FORM_DATA`
- `PARSE_REQUEST_BODY`
- `PARSE_SEARCH_PARAMS`
- `PARSE_PATH_PARAMS`

Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messaging during parsing errors by including additional context. This update provides clearer diagnostic information when issues occur, aiding troubleshooting without altering the public functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->